### PR TITLE
Fix update unexpected attribute value to product flat table

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -345,7 +345,7 @@ class FlatTableBuilder
                     $select = $this->_connection->select()
                         ->joinInner(
                             ['e' => $this->resource->getTableName('catalog_product_entity')],
-                            'e.entity_id = et.entity_id',
+                            'e.entity_id = et.entity_id AND e.row_id = et.row_id',
                             []
                         )->joinInner(
                             ['t' => $tableName],


### PR DESCRIPTION
After filling flat product data, Magento query attribute values by store then use it to update flat product table.
When query attribute values by store, Magento don't check row_id. If attribute value has multiple version, an unexpected value is used to update flat product data.
